### PR TITLE
Fixes for linux-4.7

### DIFF
--- a/rtl8192eu/os_dep/linux/ioctl_cfg80211.c
+++ b/rtl8192eu/os_dep/linux/ioctl_cfg80211.c
@@ -31,6 +31,17 @@
 #define STATION_INFO_ASSOC_REQ_IES	0
 #endif /* Linux kernel >= 4.0.0 */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
+enum ieee80211_band {
+        IEEE80211_BAND_2GHZ = NL80211_BAND_2GHZ,
+        IEEE80211_BAND_5GHZ = NL80211_BAND_5GHZ,
+        IEEE80211_BAND_60GHZ = NL80211_BAND_60GHZ,
+
+        /* keep last */
+        IEEE80211_NUM_BANDS
+};
+#endif /* Linux kernel >= 4.7.0 */
+
 #include <rtw_wifi_regd.h>
 
 #define RTW_MAX_MGMT_TX_CNT (8)

--- a/rtl8192eu/os_dep/linux/wifi_regd.c
+++ b/rtl8192eu/os_dep/linux/wifi_regd.c
@@ -10,6 +10,12 @@
 
 #include <rtw_wifi_regd.h>
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
+#define IEEE80211_BAND_2GHZ    NL80211_BAND_2GHZ
+#define IEEE80211_BAND_5GHZ    NL80211_BAND_5GHZ
+#define IEEE80211_NUM_BANDS    NUM_NL80211_BANDS
+#endif /* Linux kernel >= 4.7.0 */
+
 static struct country_code_to_enum_rd allCountries[] = {
 	{COUNTRY_CODE_USER, "RD"},
 };


### PR DESCRIPTION
### My edits to make the Realtek v.4.4.1 kernel module compile, needs further testing.

- Changes should works for linux-4.4 to linux-4.7, after that we can merge.